### PR TITLE
Add flag to include hidden files and directories

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -15,17 +15,17 @@ struct Cli {
     #[clap(default_value = "./")]
     path: String,
 
+    /// Show a diff for each non-formatted file.
+    #[clap(short, long, default_missing_value = "true")]
+    diff: bool,
+
     /// Include or exclude files to format.
     #[clap(short, long)]
     glob: Vec<String>,
 
-    /// The approximate number of threads to use.
-    #[clap(short, long)]
-    parallel: Option<usize>,
-
-    /// Show a diff for each non-formatted file.
-    #[clap(short, long, default_missing_value = "true")]
-    diff: bool,
+    /// Include hidden files and directories.
+    #[clap(short = '.', long, default_missing_value = "true")]
+    hidden: bool,
 
     /// List all files processed, including formatted ones.
     #[clap(short, long, default_missing_value = "true")]
@@ -34,6 +34,10 @@ struct Cli {
     /// Do not respect .gitignore files.
     #[clap(long, default_missing_value = "true")]
     no_gitignore: bool,
+
+    /// The approximate number of threads to use.
+    #[clap(short, long)]
+    parallel: Option<usize>,
 
     /// Do not print info to stderr.
     #[clap(short, long, default_missing_value = "true")]
@@ -47,6 +51,7 @@ struct Cli {
 fn main() {
     let cli = Cli::parse();
     let opts = Options {
+        hidden: cli.hidden,
         globs: cli.glob,
         parallel: cli.parallel,
         diff: cli.diff,

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -19,6 +19,7 @@ use crate::types::{json::Json, markdown::Markdown, sql::Sql, toml::Toml, yaml::Y
 
 #[derive(Default, Clone)]
 pub(crate) struct Options {
+    pub(crate) hidden: bool,
     pub(crate) globs: Vec<String>,
     pub(crate) parallel: Option<usize>,
     pub(crate) diff: bool,
@@ -104,6 +105,7 @@ fn build_walk(root: &str, ops: &Options, writer: Arc<BufferWriter>) -> Option<Wa
     let mut builder = WalkBuilder::new(root);
     let num_threads = ops.parallel.unwrap_or_else(num_cpus::get).max(1);
     builder
+        .hidden(!ops.hidden)
         .threads(num_threads)
         .add_custom_ignore_filename(".metafmtignore")
         .git_ignore(!ops.no_gitignore);


### PR DESCRIPTION
Adds a new flag `--hidden` (or `-.`) to include hidden files and directories. This PR also reorders the flags alphabetically.