### PR TITLE
Add flag to disable all ignore-related filtering

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -31,9 +31,9 @@ struct Cli {
     #[clap(short, long, default_missing_value = "true")]
     list_all: bool,
 
-    /// Do not respect .gitignore files.
+    /// Disable all ignore-related filtering.
     #[clap(long, default_missing_value = "true")]
-    no_gitignore: bool,
+    no_ignore: bool,
 
     /// The approximate number of threads to use.
     #[clap(short, long)]
@@ -56,7 +56,7 @@ fn main() {
         parallel: cli.parallel,
         diff: cli.diff,
         list_all: cli.list_all,
-        no_gitignore: cli.no_gitignore,
+        no_ignore: cli.no_ignore,
         quiet: cli.quiet,
         write: cli.write,
     };

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -24,7 +24,7 @@ pub(crate) struct Options {
     pub(crate) parallel: Option<usize>,
     pub(crate) diff: bool,
     pub(crate) list_all: bool,
-    pub(crate) no_gitignore: bool,
+    pub(crate) no_ignore: bool,
     pub(crate) quiet: bool,
     pub(crate) write: bool,
 }
@@ -107,10 +107,13 @@ fn build_walk(root: &str, ops: &Options, writer: Arc<BufferWriter>) -> Option<Wa
     builder
         .hidden(!ops.hidden)
         .threads(num_threads)
-        .add_custom_ignore_filename(".metafmtignore")
-        .git_ignore(!ops.no_gitignore);
+        .ignore(!ops.no_ignore)
+        .git_ignore(!ops.no_ignore);
     if num_threads == 1 {
         builder.sort_by_file_path(|p1, p2| p1.cmp(p2));
+    }
+    if !ops.no_ignore {
+        builder.add_custom_ignore_filename(".metafmtignore");
     }
     if !ops.globs.is_empty() {
         let mut override_builder = OverrideBuilder::new(root);


### PR DESCRIPTION
This PR adds a new flag `--no-ignore` and removes the existing flag `--no-gitignore`. The new flag will disable *all* ignore-related filtering.