### PR TITLE
Add cgo as a build dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,6 +121,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cgo"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b46fb6704a5c72795ab9e1dda1b1bcabfbb22e403f22d08d3bcd5934d66ff3c"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "clap"
 version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -494,6 +503,7 @@ name = "metafmt"
 version = "0.1.0"
 dependencies = [
  "atty",
+ "cgo",
  "clap",
  "cmarkfmt",
  "crossbeam",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,6 @@ num_cpus = { version = "1.15.0" }
 sqlformat = { version = "0.2.1" }
 termcolor = { version = "1.2.0" }
 toml_edit = { version = "0.19.10" }
+
+[build-dependencies]
+cgo = { version = "0.2.0" }

--- a/build.rs
+++ b/build.rs
@@ -1,23 +1,10 @@
-use std::process::Command;
-
 fn main() {
-    let out_dir = std::env::var("OUT_DIR").unwrap();
-    Command::new("go")
-        .args([
-            "build",
-            "-buildmode",
-            "c-archive",
-            "-ldflags",
-            "-s -w",
-            "-o",
-            &format!("{}/libyaml.a", out_dir),
-            "pkg/yaml.go",
-        ])
-        .status()
-        .expect("building Go yaml library failed");
+    cgo::Build::new()
+        .trimpath(true)
+        .ldflags("-s -w")
+        .package("pkg/yaml.go")
+        .build("metayaml");
 
     println!("cargo:rerun-if-changed=pkg");
     println!("cargo:rerun-if-changed=go.mod");
-    println!("cargo:rustc-link-search=native={}", out_dir);
-    println!("cargo:rustc-link-lib=static=yaml");
 }


### PR DESCRIPTION
This PR uses the [cgo](https://crates.io/crates/cgo) crate instead of custom Go compilation code within the `build.rs` file.