### PR TITLE
Remove musl release targets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,24 +17,16 @@ jobs:
       matrix:
         build:
           - linux-x86_64
-          - linux-x86_64-musl
           - linux-arm64
-          - linux-arm64-musl
           - macos-x86_64
           - macos-arm64
         include:
           - build: linux-x86_64
             os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
-          - build: linux-x86_64-musl
-            os: ubuntu-22.04
-            target: x86_64-unknown-linux-musl
           - build: linux-arm64
             os: ubuntu-22.04
             target: aarch64-unknown-linux-gnu
-          - build: linux-arm64-musl
-            os: ubuntu-22.04
-            target: aarch64-unknown-linux-musl
           - build: macos-x86_64
             os: macos-12
             target: x86_64-apple-darwin


### PR DESCRIPTION
Currently, the Go being compiled into the binary is not working correctly with musl. I'll have to figure out that issue with `cgo` first.