### PR TITLE
Add ability to update metafmt in-place

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,6 @@ jobs:
           - linux-x86_64
           - macos-arm64
           - macos-x86_64
-          - windows-x86_64
         include:
           - build: freebsd-x86_64
             os: ubuntu-22.04
@@ -87,9 +86,6 @@ jobs:
           - build: macos-x86_64
             os: macos-12
             target: x86_64-apple-darwin
-          - build: windows-x86_64
-            os: ubuntu-22.04
-            target: x86_64-pc-windows-gnu
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,6 @@ jobs:
           - linux-x86_64
           - macos-arm64
           - macos-x86_64
-          - windows-x86_64
         include:
           - build: freebsd-x86_64
             os: ubuntu-22.04
@@ -42,9 +41,6 @@ jobs:
           - build: macos-arm64
             os: macos-12
             target: aarch64-apple-darwin
-          - build: windows-x86_64
-            os: ubuntu-22.04
-            target: x86_64-pc-windows-gnu
     steps:
       - uses: actions/checkout@v3
 
@@ -73,15 +69,9 @@ jobs:
         shell: bash
         run: |
           staging="metafmt-${{ github.ref_name }}-${{ matrix.target }}"
-          if [ "${{ matrix.target }}" = "x86_64-pc-windows-gnu" ]; then
-            cp "target/${{ matrix.target }}/release/metafmt.exe" metafmt.exe
-            zip "$staging.zip" metafmt.exe
-            echo "ASSET=$staging.zip" >> $GITHUB_ENV
-          else
-            cp "target/${{ matrix.target }}/release/metafmt" metafmt
-            tar czf "$staging.tar.gz" metafmt
-            echo "ASSET=$staging.tar.gz" >> $GITHUB_ENV
-          fi
+          cp "target/${{ matrix.target }}/release/metafmt" metafmt
+          tar czf "$staging.tar.gz" metafmt
+          echo "ASSET=$staging.tar.gz" >> $GITHUB_ENV
 
       - name: Upload release archive
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -93,6 +99,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -107,6 +119,18 @@ dependencies = [
  "memchr",
  "serde",
 ]
+
+[[package]]
+name = "bumpalo"
+version = "3.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
+
+[[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "cc"
@@ -185,6 +209,15 @@ name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "crossbeam"
@@ -296,6 +329,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
 
 [[package]]
+name = "filetime"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cbc844cecaee9d4443931972e1289c8ff485cb4cc2767cb03ca139ed6885153"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "windows-sys",
+]
+
+[[package]]
 name = "fjson"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -305,10 +350,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "flate2"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "getopts"
@@ -317,6 +381,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
 dependencies = [
  "unicode-width",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -367,6 +442,16 @@ name = "hermit-abi"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+
+[[package]]
+name = "idna"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
 
 [[package]]
 name = "ignore"
@@ -428,6 +513,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+
+[[package]]
 name = "jemalloc-sys"
 version = "0.5.3+5.3.0-patched"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -445,6 +536,15 @@ checksum = "16c2514137880c52b0b4822b563fadd38257c1f380858addb74a400889696ea6"
 dependencies = [
  "jemalloc-sys",
  "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
+dependencies = [
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -498,12 +598,18 @@ dependencies = [
  "diffy",
  "fastrand",
  "fjson",
+ "flate2",
  "ignore",
  "jemallocator",
  "num_cpus",
+ "rand",
+ "serde",
  "sqlformat",
+ "tar",
  "termcolor",
  "toml_edit",
+ "ureq",
+ "zip",
 ]
 
 [[package]]
@@ -511,6 +617,15 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+dependencies = [
+ "adler",
+]
 
 [[package]]
 name = "nom"
@@ -555,6 +670,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -585,6 +712,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -602,6 +768,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin",
+ "untrusted",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "rustix"
 version = "0.37.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -614,6 +795,24 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys",
 ]
+
+[[package]]
+name = "rustls"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
+dependencies = [
+ "log",
+ "ring",
+ "sct",
+ "webpki",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "same-file"
@@ -631,10 +830,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
+name = "sct"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.164"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.96"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "sqlformat"
@@ -665,6 +905,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b55807c0344e1e6c04d7c965f5289c39a8d94ae23ed5c0b57aabac549f871c6"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -682,6 +933,21 @@ dependencies = [
  "cfg-if",
  "once_cell",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "toml_datetime"
@@ -710,10 +976,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-width"
@@ -726,6 +1007,41 @@ name = "unicode_categories"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "ureq"
+version = "2.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "338b31dd1314f68f3aabf3ed57ab922df95ffcd902476ca7ba3c4ce7b908c46d"
+dependencies = [
+ "base64",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls",
+ "serde",
+ "serde_json",
+ "url",
+ "webpki",
+ "webpki-roots",
+]
+
+[[package]]
+name = "url"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
 
 [[package]]
 name = "utf8parse"
@@ -747,6 +1063,95 @@ checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+
+[[package]]
+name = "web-sys"
+version = "0.3.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
+dependencies = [
+ "webpki",
 ]
 
 [[package]]
@@ -853,4 +1258,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61de7bac303dc551fe038e2b3cef0f571087a47571ea6e79a87692ac99b99699"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "xattr"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "zip"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+dependencies = [
+ "byteorder",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,12 +127,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
-name = "byteorder"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
-
-[[package]]
 name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -609,7 +603,6 @@ dependencies = [
  "termcolor",
  "toml_edit",
  "ureq",
- "zip",
 ]
 
 [[package]]
@@ -1267,16 +1260,4 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "zip"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
-dependencies = [
- "byteorder",
- "crc32fast",
- "crossbeam-utils",
- "flate2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,20 +29,15 @@ fastrand = { version = "2.0.0" }
 fjson = { version = "0.3.1" }
 flate2 = { version = "1.0.26" }
 ignore = { version = "0.4.20" }
+jemallocator = { version = "0.5.0" }
 num_cpus = { version = "1.15.0" }
 rand = { version = "0.8.5" }
 serde = { version = "1.0.164", features = ["derive"] }
 sqlformat = { version = "0.2.1" }
+tar = { version = "0.4.38" }
 termcolor = { version = "1.2.0" }
 toml_edit = { version = "0.19.10" }
 ureq = { version = "2.6.2", features = ["json"] }
-
-[target.'cfg(target_os = "windows")'.dependencies]
-zip = { version = "0.6.6", default-features = false, features = ["deflate"] }
-
-[target.'cfg(not(target_os = "windows"))'.dependencies]
-jemallocator = { version = "0.5.0" }
-tar = { version = "0.4.38" }
 
 [build-dependencies]
 cgo = { version = "0.2.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Ryan Fowler"]
 description = "A CLI for formatting configuration files"
 repository = "https://github.com/ryanfowler/metafmt"
 license = "MIT"
-exclude = ["/bin"]
+exclude = ["/.github", "/ci"]
 
 [[bin]]
 name = "metafmt"
@@ -27,14 +27,22 @@ crossbeam = { version = "0.8.2" }
 diffy = { version = "0.3.0" }
 fastrand = { version = "2.0.0" }
 fjson = { version = "0.3.1" }
+flate2 = { version = "1.0.26" }
 ignore = { version = "0.4.20" }
 num_cpus = { version = "1.15.0" }
+rand = { version = "0.8.5" }
+serde = { version = "1.0.164", features = ["derive"] }
 sqlformat = { version = "0.2.1" }
 termcolor = { version = "1.2.0" }
 toml_edit = { version = "0.19.10" }
+ureq = { version = "2.6.2", features = ["json"] }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+zip = { version = "0.6.6", default-features = false, features = ["deflate"] }
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
 jemallocator = { version = "0.5.0" }
+tar = { version = "0.4.38" }
 
 [build-dependencies]
 cgo = { version = "0.2.0" }

--- a/build.rs
+++ b/build.rs
@@ -7,4 +7,8 @@ fn main() {
 
     println!("cargo:rerun-if-changed=pkg");
     println!("cargo:rerun-if-changed=go.mod");
+
+    let target = std::env::var("TARGET").unwrap();
+    println!("cargo:rustc-env=TARGET={target}");
+    println!("cargo:rerun-if-changed-env=TARGET");
 }

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -29,7 +29,7 @@ pub(crate) struct Options {
     pub(crate) write: bool,
 }
 
-pub(crate) fn walk(root: String, ops: Options) -> i32 {
+pub(crate) fn format(root: String, ops: Options) -> i32 {
     let js = Json::default();
     let md = Markdown::default();
     let sql = Sql::default();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,9 @@
+mod fmt;
 mod types;
-mod walk;
 
 use clap::Parser;
 
-use walk::{walk, Options};
+use fmt::{format, Options};
 
 #[cfg(not(target_os = "windows"))]
 #[global_allocator]
@@ -61,6 +61,6 @@ fn main() {
         quiet: cli.quiet,
         write: cli.write,
     };
-    let code = walk(cli.path, opts);
-    std::process::exit(code);
+    let exit_code = format(cli.path, opts);
+    std::process::exit(exit_code);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,8 @@
 mod fmt;
 mod types;
+mod update;
 
 use clap::Parser;
-
-use fmt::{format, Options};
 
 #[cfg(not(target_os = "windows"))]
 #[global_allocator]
@@ -44,6 +43,10 @@ struct Cli {
     #[clap(short, long, default_missing_value = "true")]
     quiet: bool,
 
+    /// Update metafmt to the latest version.
+    #[clap(short, long, default_missing_value = "true")]
+    update: bool,
+
     /// Rewrite files in-place.
     #[clap(short, long, default_missing_value = "true")]
     write: bool,
@@ -51,16 +54,24 @@ struct Cli {
 
 fn main() {
     let cli = Cli::parse();
-    let opts = Options {
-        hidden: cli.hidden,
-        globs: cli.glob,
-        parallel: cli.parallel,
-        diff: cli.diff,
-        list_all: cli.list_all,
-        no_ignore: cli.no_ignore,
-        quiet: cli.quiet,
-        write: cli.write,
+
+    let exit_code = if cli.update {
+        update::update()
+    } else {
+        fmt::format(
+            cli.path,
+            fmt::Options {
+                hidden: cli.hidden,
+                globs: cli.glob,
+                parallel: cli.parallel,
+                diff: cli.diff,
+                list_all: cli.list_all,
+                no_ignore: cli.no_ignore,
+                quiet: cli.quiet,
+                write: cli.write,
+            },
+        )
     };
-    let exit_code = format(cli.path, opts);
+
     std::process::exit(exit_code);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,6 @@ mod update;
 
 use clap::Parser;
 
-#[cfg(not(target_os = "windows"))]
 #[global_allocator]
 static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
 

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,0 +1,158 @@
+use std::{
+    env, fs,
+    io::{Read, Write},
+    path::{Path, PathBuf},
+    time::Duration,
+};
+
+use flate2::read::GzDecoder;
+use rand::distributions::{Alphanumeric, DistString};
+use serde::Deserialize;
+use termcolor::{BufferWriter, Color, ColorChoice, ColorSpec, WriteColor};
+use ureq::{Agent, AgentBuilder};
+
+#[cfg(not(target_os = "windows"))]
+static ARTIFACT: &str = "metafmt";
+
+#[cfg(target_os = "windows")]
+static ARTIFACT: &str = "metafmt.exe";
+
+#[cfg(not(target_os = "windows"))]
+static EXTENSION: &str = "tar.gz";
+
+#[cfg(target_os = "windows")]
+static EXTENSION: &str = "zip";
+
+static TARGET: &str = env!("TARGET");
+static VERSION: &str = env!("CARGO_PKG_VERSION");
+
+pub(crate) fn update() -> i32 {
+    let writer = new_writer();
+    match update_inner(&writer) {
+        Ok(version) => {
+            let mut buf = writer.buffer();
+            _ = writeln!(&mut buf);
+            if let Some(version) = version {
+                _ = writeln!(&mut buf, "  metafmt updated to version: {version}");
+            } else {
+                _ = writeln!(&mut buf, "  metafmt already on latest version: v{VERSION}");
+            }
+            _ = writer.print(&buf);
+            0
+        }
+        Err(err) => {
+            write_error(&writer, &err.to_string());
+            1
+        }
+    }
+}
+
+type Error = Box<dyn std::error::Error>;
+
+pub(crate) fn update_inner(writer: &BufferWriter) -> Result<Option<String>, Error> {
+    let agent = AgentBuilder::new()
+        .timeout(Duration::from_secs(300))
+        .user_agent(&format!("metafmt/{VERSION}"))
+        .build();
+
+    let latest = get_latest_info(writer, &agent)?;
+    if latest.trim_start_matches('v') == VERSION {
+        return Ok(None);
+    }
+
+    let temp_dir = TempDir::new()?;
+    let reader = download_artifact(writer, &agent, &latest)?;
+    unpack_artifact(&temp_dir.0, reader)?;
+
+    let exe_path = env::current_exe()?;
+    let src = Path::new(&temp_dir.0).join(ARTIFACT);
+    fs::rename(src, exe_path)?;
+
+    Ok(Some(latest))
+}
+
+fn new_writer() -> BufferWriter {
+    let is_atty = atty::is(atty::Stream::Stderr);
+    BufferWriter::stderr(if is_atty {
+        ColorChoice::Always
+    } else {
+        ColorChoice::Never
+    })
+}
+
+fn get_latest_info(writer: &BufferWriter, agent: &Agent) -> Result<String, Error> {
+    #[derive(Deserialize)]
+    struct Response {
+        tag_name: String,
+    }
+
+    write_info(writer, "fetching latest version metadata");
+    let res: Response = agent
+        .get("https://api.github.com/repos/ryanfowler/metafmt/releases/latest")
+        .call()?
+        .into_json()?;
+
+    Ok(res.tag_name)
+}
+
+fn download_artifact(writer: &BufferWriter, agent: &Agent, tag: &str) -> Result<impl Read, Error> {
+    write_info(writer, &format!("downloading artifact for version: {tag}"));
+    let url = format!("https://github.com/ryanfowler/metafmt/releases/download/{tag}/metafmt-{tag}-{TARGET}.{EXTENSION}");
+    let response = agent.get(&url).call()?;
+    let status = response.status();
+    if status != 200 {
+        Err(format!("downloading artifact: received status: {status}").into())
+    } else {
+        Ok(response.into_reader())
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+fn unpack_artifact(temp_dir: &PathBuf, r: impl Read) -> Result<(), std::io::Error> {
+    let gz = GzDecoder::new(r);
+    let mut archive = tar::Archive::new(gz);
+    archive.unpack(temp_dir)
+}
+
+#[cfg(target_os = "windows")]
+fn unpack_artifact(temp_dir: &PathBuf, r: impl Read) -> Result<(), std::io::Error> {
+    let mut z = zip::ZipArchive::new(r);
+    let mut archive = Archive::new(gz);
+    archive.unpack(temp_dir)
+}
+
+fn write_info(writer: &BufferWriter, msg: &str) {
+    let mut buf = writer.buffer();
+    _ = buf.set_color(ColorSpec::new().set_fg(Some(Color::Green)).set_bold(true));
+    _ = write!(buf, "info:");
+    _ = buf.reset();
+    _ = writeln!(&mut buf, " {msg}");
+    _ = writer.print(&buf);
+}
+
+fn write_error(writer: &BufferWriter, msg: &str) {
+    let mut buf = writer.buffer();
+    _ = buf.set_color(ColorSpec::new().set_fg(Some(Color::Red)).set_bold(true));
+    _ = write!(&mut buf, "error:");
+    _ = buf.reset();
+    _ = writeln!(&mut buf, " {msg}");
+    _ = writer.print(&buf);
+}
+
+struct TempDir(PathBuf);
+
+impl TempDir {
+    fn new() -> Result<Self, std::io::Error> {
+        let mut dir = env::temp_dir();
+        let sample = Alphanumeric.sample_string(&mut rand::thread_rng(), 16);
+        dir.push(format!("metafmt-{sample}"));
+        fs::create_dir(&dir)?;
+        Ok(Self(dir))
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        _ = fs::remove_dir_all(&self.0);
+    }
+}


### PR DESCRIPTION
Add a new flag (`--update`) to update metafmt in-place to the latest release according to github.