### PR TITLE
Format content from stdin to stdout

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,15 +33,16 @@ Arguments:
   [PATH]  A file or directory to format [default: ./]
 
 Options:
-  -d, --diff                 Show a diff for each non-formatted file
-  -g, --glob <GLOB>          Include or exclude files to format
-  -., --hidden               Include hidden files and directories
-  -l, --list-all             List all files processed, including formatted ones
-      --no-ignore            Disable all ignore-related filtering
-  -p, --parallel <PARALLEL>  The approximate number of threads to use
-  -q, --quiet                Do not print info to stderr
-  -u, --update               Update metafmt to the latest version
-  -w, --write                Rewrite files in-place
-  -h, --help                 Print help
-  -V, --version              Print version
+  -d, --diff                             Show a diff for each non-formatted file
+  -g, --glob <GLOB>                      Include or exclude files to format
+  -., --hidden                           Include hidden files and directories
+  -l, --list-all                         List all files processed, including formatted ones
+      --no-ignore                        Disable all ignore-related filtering
+  -p, --parallel <PARALLEL>              The approximate number of threads to use
+      --stdin-filetype <STDIN_FILETYPE>  The filetype of the data provided via stdin
+  -q, --quiet                            Do not print info to stderr
+  -u, --update                           Update metafmt to the latest version
+  -w, --write                            Rewrite files in-place
+  -h, --help                             Print help
+  -V, --version                          Print version
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod fmt;
+mod stdin;
 mod types;
 mod update;
 
@@ -38,6 +39,10 @@ struct Cli {
     #[clap(short, long)]
     parallel: Option<usize>,
 
+    /// The filetype of the data provided via stdin.
+    #[clap(long)]
+    stdin_filetype: Option<String>,
+
     /// Do not print info to stderr.
     #[clap(short, long, default_missing_value = "true")]
     quiet: bool,
@@ -56,6 +61,8 @@ fn main() {
 
     let exit_code = if cli.update {
         update::update()
+    } else if cli.path == "-" {
+        stdin::format(cli.stdin_filetype)
     } else {
         fmt::format(
             cli.path,

--- a/src/stdin.rs
+++ b/src/stdin.rs
@@ -1,0 +1,45 @@
+use std::io::{self, Read, Write};
+
+use crate::types::{json::Json, markdown::Markdown, sql::Sql, toml::Toml, yaml::Yaml, Format};
+
+pub(crate) fn format(filetype: Option<String>) -> i32 {
+    let Some(filetype) = filetype else {
+        eprintln!("error: the '--stdin-filetype' flag must be provided");
+        return 1;
+    };
+
+    let mut input = String::new();
+    if let Err(err) = io::stdin().read_to_string(&mut input) {
+        eprintln!("error: {}", err);
+        return 1;
+    }
+
+    match filetype.as_str() {
+        "json" => format_file(&input, Json::default()),
+        "md" | "markdown" => format_file(&input, Markdown::default()),
+        "sql" => format_file(&input, Sql::default()),
+        "toml" => format_file(&input, Toml::default()),
+        "yaml" | "yml" => format_file(&input, Yaml::default()),
+        format => {
+            eprintln!("error: unknown format '{}'", format);
+            1
+        }
+    }
+}
+
+fn format_file(input: &str, formatter: impl Format) -> i32 {
+    let output = match formatter.format(input) {
+        Ok(output) => output,
+        Err(err) => {
+            eprintln!("error: {}", err);
+            return 1;
+        }
+    };
+
+    if let Err(err) = io::stdout().write_all(output.as_bytes()) {
+        eprintln!("error: {}", err);
+        return 1;
+    }
+
+    0
+}


### PR DESCRIPTION
Allow formatting of content from stdin by passing in `-` as the path component to `metafmt`:

```sh
cat Cargo.toml | metafmt - --stdin-filetype toml
```