### PR TITLE
Update CI Go version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   CROSS_VERSION: "0.2.5"
-  GO_VERSION: "1.24.0"
+  GO_VERSION: "1.24.4"
   RUST_VERSION: "1.88.0"
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   CROSS_VERSION: "0.2.5"
-  GO_VERSION: "1.24.0"
+  GO_VERSION: "1.24.4"
   RUST_VERSION: "1.88.0"
 
 jobs:

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,6 +1,6 @@
 ARG CROSS_BASE_IMAGE
 FROM $CROSS_BASE_IMAGE
-ENV GO_VERSION=1.24.0
+ENV GO_VERSION=1.24.4
 RUN apt-get update && apt-get -y install wget && \
     wget -qO go${GO_VERSION}.linux-amd64.tar.gz https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz && \
     tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz


### PR DESCRIPTION
## Summary
- update Go version for CI and release workflows to 1.24.4
- bump the CI Dockerfile Go version

## Testing
- `PATH=/usr/local/go/bin:$PATH GOTOOLCHAIN=local go test ./...`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_685dc4ce76988325b43e25a7fd5951ac